### PR TITLE
Fixed the fail to create and build issue with Xcode 7.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lib/iOSProject.js
+++ b/lib/iOSProject.js
@@ -26,9 +26,7 @@ function iOSPlatform(PlatformBase, platformData) {
      */
     iOSProject.prototype.create =
     function(packageId, args, callback) {
-        // TODO implement generation of project.
         var output = this.application.output;
-        output.info("iOSProject: Generating " + packageId);
 
         var parts = packageId.split('.');
         var project_name = parts[parts.length - 1];
@@ -49,48 +47,52 @@ function iOSPlatform(PlatformBase, platformData) {
             return;
         }
 
-        Shell.mkdir('-p', this.pkgPath);
-        this.logOutput.info('Created package directory: ' + this.pkgPath);
-
         Shell.mkdir('-p', this.platformPath);
+        this.logOutput.info('Created platform directory: ' + this.platformPath);
         // TODO(jondong): Use node git module instead of running git command
         // directly, in case the host platform hasn't get git installed.
-        var cmdClone = ['git', 'clone', 'https://github.com/crosswalk-project/crosswalk-ios.git', this.platformPath];
-        Shell.exec(cmdClone.join(' '));
-        this.logOutput.info('Clone project template into: ' + this.platformPath);
-
-        Shell.pushd(this.platformPath);
-        var cmdInit = ['git', 'submodule', 'update', '--init', '--recursive'];
-        Shell.exec(cmdInit.join(' '));
-
-        Shell.pushd(project_dir);
-        Shell.ls (".").filter (function (file) {
-            var new_file = file.replace (/AppShell/gi, project_name);
-            if (file != new_file)
-                Shell.mv ('-f', file, new_file);
+        var that = this;
+        var createPromise = new Promise(function(resolve, reject){
+            var progress = output.createInfiniteProgress('Clone project');
+            var counter = 0;
+            var intervalId = setInterval(function(c) {
+                progress.update('in progress: ' + ++counter);
+            }, 1000);
+            var cmdClone = ['git', 'clone', 'https://github.com/crosswalk-project/crosswalk-ios.git', that.platformPath];
+            Shell.exec(cmdClone.join(' '), {async:true}, function(code, out){
+                clearInterval(intervalId);
+                progress.done('Cloned.');
+                if (code == 0) {
+                    resolve();
+                } else {
+                    reject(code, out);
+                }
+            });
         });
-        var xcodeproj = project_name+".xcodeproj";
-        Shell.find (xcodeproj).filter (function (file) {
-            if (Shell.test ('-f', file)) {
-                Shell.sed ('-i', /AppShell/gi, project_name, file);
-                Shell.mv('-f', file, file.replace (/AppShell/gi, project_name));
+
+        createPromise.then(function() {
+            if (Shell.which('pod') == null) {
+                callback("You haven't install CocoaPods onto your local machine, which is needed to create your iOS application. Use 'sudo gem install cocoapods' to install the latest version. For more information about CocoaPods, please refer to: https://cocoapods.org/");
+                return;
             }
+            var progress = output.createInfiniteProgress('CocoaPods install');
+            var counter = 0;
+            var intervalId = setInterval(function(c) {
+                progress.update('in progress: ' + ++counter);
+            }, 1000);
+            Shell.pushd(project_dir);
+            var cmdInit = ['pod', 'install'];
+            Shell.exec(cmdInit.join(' '), {async:true}, function(code, out){
+                clearInterval(intervalId);
+                progress.done('Installed.');
+                Shell.popd();
+                if (code != 0) {
+                    callback(out);
+                }
+            });
+        }, function(code, out) {
+            callback(out);
         });
-        this.logOutput.info('Convert project name into: ' + project_name);
-
-        // Replace package name in info.plist.
-        var info_file = Path.join(project_dir, project_name, 'Info.plist');
-        var project_name_prefix = Path.basename(packageId, '.' + project_name);
-        if (Shell.test('-f', info_file)) {
-            Shell.sed('-i', /org.crosswalk-project/gi, project_name_prefix, info_file);
-        }
-
-        Shell.popd();
-        Shell.popd();
-
-        // Null means success, error string means failure.
-        callback(null);
-        return;
     }
 
     iOSProject.prototype.update =
@@ -134,11 +136,7 @@ function iOSPlatform(PlatformBase, platformData) {
     iOSProject.prototype.build =
         function(configId, args, callback) {
             var output = this.application.output;
-
             var packageId = Path.basename(Shell.pwd());
-            // TODO implement updating of project to new Crosswalk version.
-            output.info("iOSProject: Building project " + packageId);
-
             var Fs = require ('fs');
 
             var project_dir = Path.join(this.platformPath, 'AppShell');
@@ -150,7 +148,7 @@ function iOSPlatform(PlatformBase, platformData) {
                 return;
             }
 
-            output.info('Start to update the web resources.');
+            output.info('Update web resources.');
 
             if (Shell.test('-d', Path.join(project_dir, 'www'))) {
                 Shell.rm('-rf', Path.join(project_dir, 'www'));
@@ -161,55 +159,38 @@ function iOSPlatform(PlatformBase, platformData) {
             this.logOutput.info('Copy application contents from: ' + this.appPath + ' to: ' + project_dir);
             Shell.mv('-f', Path.join(project_dir, 'app'), Path.join(project_dir, 'www'));
 
+            // Generate manifest.plist file
+            output.info('Generate manifest.plist file.');
             Shell.pushd(project_dir);
-            var project_path = Path.join(project_dir, project_name + '.xcodeproj', 'project.pbxproj');
-            var project = require ('xcode').project(project_path);
-            var Plist = require('plist');
-            var Manifest = require(Path.join(project_dir, 'www', 'manifest.json'));
-            var version = Manifest.xwalk_version || Manifest.version || "0.1";
+            var manifest = require(Path.join(project_dir, 'www', 'manifest.json'));
+            var version = manifest.xwalk_version || manifest.version || "0.1";
             this.logOutput.info('Check the version of manifest.json.');
             if (!this.checkVersion(version)) {
                 callback("Application version is wrong.");
                 return;
             }
+            var Plist = require('plist');
+            Fs.writeFileSync(Path.join(project_dir, 'www', 'manifest.plist'), Plist.build(manifest));
+            this.logOutput.info('Generate manifest.plist file from manifest.json.');
+            var options = {'path': project_dir, 'id': packageId, 'version': version};
 
-            project.parse(function (err) {
-                var output = this.application.output;
-
-                // Generate manifest.plist file
-                Fs.writeFileSync(Path.join(project_dir, 'www', 'manifest.plist'), Plist.build(Manifest));
-                this.logOutput.info('Generate manifest.plist file from manifest.json.');
-                // Replace the application version number
-                var info_file = Path.join(project_dir, project_name, 'Info.plist');
-                var info = Plist.parse(Fs.readFileSync(info_file, 'utf8'));
-                info.CFBundleShortVersionString = version;
-                Shell.rm('-f', info_file);
-                Fs.writeFileSync(info_file, Plist.build(info));
-                this.logOutput.info('Replace the application\'s version number.');
-                // Add the real resource files.
-                Shell.pushd(Path.join(project_dir, 'www'));
+            if (args.sdk)
+                options.sdk = args.sdk;
+            if (args.sign)
+                options.sign = args.sign;
+            if (args.provision)
+                options.provision = args.provision;
+            this.logOutput.info('Create SDK object to execute the actual build.');
+            var sdk = new SDK(this.application, options);
+            var that = this;
+            sdk.build(['arm64', 'armv7', 'armv7s'], configId == 'release').then(function(){
+                that.exportPackage(Shell.ls(Path.join(project_dir, 'export', project_name + '.ipa'))[0]);
                 Shell.popd();
-
-                Fs.writeFileSync(project_path, project.writeSync());
-                output.info('Finished update resources.');
-                output.info('Start to build ipa file.');
-                var options = {'path': project_dir, 'id': packageId};
-
-                if (args.sdk)
-                    options.sdk = args.sdk;
-                if (args.sign)
-                    options.sign = args.sign;
-                if (args.provision)
-                    options.provision = args.provision;
-                this.logOutput.info('Create SDK object to execute the actual build.');
-                var sdk = new SDK(this.application, options);
-                if (sdk.build(['arm64', 'armv7', 'armv7s'], configId == 'release')) {
-                    this.exportPackage(Shell.ls(Path.join(project_dir, 'build', project_name + '*.ipa'))[0]);
-                }
-            }.bind(this));
-            Shell.popd();
-            // Null means success, error string means failure.
-            callback(null);
+                callback(null);
+            }, function(code, out){
+                Shell.popd();
+                callback(out);
+            });
         };
     return new iOSProject(PlatformBase, platformData);
 }

--- a/lib/iOSSDK.js
+++ b/lib/iOSSDK.js
@@ -14,20 +14,21 @@ var Shell = require('shelljs');
 function iOSSDK(application, config) {
     var project_path = Shell.pwd();
     var projectId = Path.basename(project_path);
+    this._application = application;
     this._sign = null;
     this._provision = null;
     if (typeof(config) != 'undefined' && config != null) {
         project_path = typeof(config.path) != 'undefined'?config.path:project_path;
         projectId = typeof(config.id) != 'undefined'?config.id:Path.basename(project_path);
+        this._version = typeof(config.version) != 'undefined' ? config.version : '0.1';
         this._sdk = typeof(config.sdk) != 'undefined'?config.sdk:'iphoneos';
         this._sign = typeof(config.sign) != 'undefined'?config.sign:null;
         this._provision = typeof(config.provision) != 'undefined'?config.provision:null;
     }
-    this._project_path = project_path;
+    this._project_path = Fs.realpathSync(project_path);
     this._project_id = projectId;
     var parts = projectId.split('.');
     this._project_name = parts[parts.length-1];
-    this._project_path = Fs.realpathSync(project_path);
     this._build_path = Path.join(this._project_path, 'build');
     if (!Shell.test('-d', this._build_path)) {
         Shell.mkdir('-p', this._build_path);
@@ -43,31 +44,50 @@ function iOSSDK(application, config) {
  * @return the build command string
  */
 iOSSDK.prototype.getBuildCmd = function(archs, release) {
-    var xcodeproj_path = Path.join(this._project_path, this._project_name + '.xcodeproj');
+    var xcworkspace_path = Path.join(this._project_path, 'AppShell.xcworkspace');
     var archs_param = '';
     if (archs != null) {
         archs_param = 'ARCHS="' + archs.join(' ') + '"';
     }
     var configuration = release?'Release':'Debug';
-    return ['xcodebuild', '-project', xcodeproj_path, archs_param,
-            '-target', this._project_name, '-configuration', configuration,
-            '-sdk', this._sdk, 'build', 'CONFIGURATION_BUILD_DIR=' + this._build_path,
-            'VALID_ARCHS="' + ['arm64', 'armv7', 'armv7s'].join(' ') + '"'].join(' ');
+    return ['xcodebuild', '-workspace', xcworkspace_path, '-scheme AppShell',
+            '-configuration', configuration, archs_param, '-sdk', this._sdk,
+            'PRODUCT_BUNDLE_IDENTIFIER=' + this._project_id,
+            'TARGET_NAME=' + this._project_name,
+            '-archivePath', 'archived', 'archive'
+           ].join(' ');
 }
 
 /**
- * getXcrunCmd
- * @return The xcrun command string
+ * getExportCmd
+ * @return The export command string
  */
-iOSSDK.prototype.getXcrunCmd = function() {
-    var cmd = ['xcrun', '-sdk', this._sdk, 'PackageApplication', '-v', this._app_path, '-o', this._ipa_path];
-    if (this._sign != null) {
-        cmd = cmd.concat(['--sign', '"' + this._sign + '"']);
-    }
-    if (this._provision != null) {
-        cmd = cmd.concat(['--embed', '"' + this._provision + '"']);
-    }
+iOSSDK.prototype.getExportCmd = function() {
+    var cmd = ['xcodebuild', '-exportArchive', '-archivePath', 'archived.xcarchive',
+              '-exportPath', 'export', '-exportOptionsPlist', 'exports.plist'
+    ];
     return cmd.join(' ');
+}
+
+iOSSDK.prototype.prepareExport = function() {
+    var output = this._application.output;
+    var Plist = require('plist');
+    var infoPath = Path.join('archived.xcarchive', 'Info.plist');
+    var info = Plist.parse(Fs.readFileSync(infoPath, 'utf8'));
+    info.ApplicationProperties.CFBundleShortVersionString = this._version;
+    info.Name = this._project_name;
+    info.SchemeName = this._project_name;
+    Fs.writeFileSync(infoPath, Plist.build(info));
+
+    var exportsPlist = Plist.build({
+        method: 'ad-hoc',
+        thinning: '<none>'
+    });
+    Fs.writeFileSync('exports.plist', exportsPlist);
+}
+
+iOSSDK.prototype.cleanupExport = function() {
+    Shell.rm('exports.plist');
 }
 
 /**
@@ -77,10 +97,50 @@ iOSSDK.prototype.getXcrunCmd = function() {
  * @return {Boolean} If the command get success.
  */
 iOSSDK.prototype.build = function(archs, release) {
+    var output = this._application.output;
+    var that = this;
+
     Shell.pushd(this._project_path);
-    var ret = Shell.exec(this.getBuildCmd(archs, release)) && Shell.exec(this.getXcrunCmd());
-    Shell.popd();
-    return ret;
+
+    return new Promise(function(resolve, reject){
+        var progress = output.createInfiniteProgress('Build application');
+        var counter = 0;
+        var intervalId = setInterval(function(c) {
+            progress.update('in progress: ' + ++counter);
+        }, 1000);
+        Shell.exec(that.getBuildCmd(archs, release), {async:true}, function(code, out){
+            clearInterval(intervalId);
+            progress.done('Built.');
+            if (code == 0) {
+                resolve();
+            } else {
+                reject(code, out);
+            }
+        });
+    }).then(function(){
+        return new Promise(function(resolve, reject){
+            var progress = output.createInfiniteProgress('Sign and export package');
+            var counter = 0;
+            var intervalId = setInterval(function(){
+                progress.update('in progress: ' + ++counter);
+            }, 1000);
+            that.prepareExport();
+            Shell.exec(that.getExportCmd(), {async:true}, function(code, out){
+                that.cleanupExport();
+                clearInterval(intervalId);
+                progress.done('Exported.');
+                Shell.popd();
+                if (code == 0) {
+                    resolve();
+                } else {
+                    output.error('Failed to export application, with return code: ' + code + ', error message: ' + out);
+                    reject(code, out);
+                }
+            });
+        });
+    }, function(code, out){
+        output.error('Failed to build application, with return code: ' + code + ', error message: ' + out);
+    });
 }
 
 /**
@@ -90,7 +150,7 @@ iOSSDK.prototype.build = function(archs, release) {
  */
 iOSSDK.prototype.cmd = function(archs, release) {
     console.log(this.getBuildCmd(archs, release));
-    console.log(this.getXcrunCmd());
+    console.log(this.getExportCmd());
 }
 
 module.exports = iOSSDK;


### PR DESCRIPTION
Major changes of this patch:
1. Updated the create command, use CocoaPods to generate the project
correctly;
2. Updated the build command, use xcodebuild with command line
arguments instead of modifying the project file directly. Also use
xcodebuild archive and export command to export the package file
instead of using xcrun which is obsoleted by Xcode 7.
3. Adopt Promise to run the command asynchronously, and use infinite
output process to indicate that the command is still alive.
4. Added .gitignore.

BUG=XWALK-5233,XWALK-5171
