### PR TITLE
fixed xcodebuild error reporting & scheme name

### DIFF
--- a/lib/iOSSDK.js
+++ b/lib/iOSSDK.js
@@ -50,7 +50,7 @@ iOSSDK.prototype.getBuildCmd = function(archs, release) {
         archs_param = 'ARCHS="' + archs.join(' ') + '"';
     }
     var configuration = release?'Release':'Debug';
-    return ['xcodebuild', '-workspace', xcworkspace_path, '-scheme AppShell',
+    return ['xcodebuild', '-workspace', xcworkspace_path, '-scheme Pods-AppShell',
             '-configuration', configuration, archs_param, '-sdk', this._sdk,
             'PRODUCT_BUNDLE_IDENTIFIER=' + this._project_id,
             'TARGET_NAME=' + this._project_name,
@@ -114,7 +114,7 @@ iOSSDK.prototype.build = function(archs, release) {
             if (code == 0) {
                 resolve();
             } else {
-                reject(code, out);
+                reject({code: code, out: out, cmd: that.getBuildCmd(archs, release)});
             }
         });
     }).then(function(){
@@ -138,8 +138,9 @@ iOSSDK.prototype.build = function(archs, release) {
                 }
             });
         });
-    }, function(code, out){
-        output.error('Failed to build application, with return code: ' + code + ', error message: ' + out);
+    }, function(res){
+        output.error('Failed to build application, with return code: ' + res.code + ', error message: ' + res.out);
+        output.error('Build command was: ' + res.cmd);
     });
 }
 


### PR DESCRIPTION
This caused https://crosswalk-project.org/documentation/ios/quick_start_guide.html to fail.
